### PR TITLE
Deconflicted having multiple ThemeStyleAppliers in hierarchy

### DIFF
--- a/DataBindingUnityProject/Assets/Scenes/SampleScene.unity
+++ b/DataBindingUnityProject/Assets/Scenes/SampleScene.unity
@@ -1148,6 +1148,197 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &775382734
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 775382735}
+  - component: {fileID: 775382739}
+  - component: {fileID: 775382738}
+  - component: {fileID: 775382737}
+  - component: {fileID: 775382736}
+  m_Layer: 5
+  m_Name: Text (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &775382735
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 775382734}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4869112576897787564}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 41.228333, y: -31.9}
+  m_SizeDelta: {x: -123.8966, y: -74.3667}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &775382736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 775382734}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5fd266799944d94438c5c9d41611d28e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  themeStyles:
+  - template: {fileID: 11400000, guid: a8f1cd482cd3b014ea8d510aaa73f04e, type: 2}
+    themeStyle: {fileID: 11400000, guid: 137dd63612b87594e801b764212f28a6, type: 2}
+--- !u!114 &775382737
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 775382734}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9e175cba8a3f0344abcd543277ca87d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  binders:
+  - rid: 4598207527680737302
+  - rid: 6402840522224042053
+  references:
+    version: 2
+    RefIds:
+    - rid: 4598207527680737302
+      type: {class: ColorThemeBinder, ns: MVVMDatabinding.Theming, asm: MVVM-Databinding}
+      data:
+        themeTemplate: {fileID: 11400000, guid: a8f1cd482cd3b014ea8d510aaa73f04e,
+          type: 2}
+        itemId: 268968527
+        name: Color (ColorThemeBinder)
+        themeStyle: {fileID: 11400000, guid: 137dd63612b87594e801b764212f28a6, type: 2}
+        targets:
+        - {fileID: 775382738}
+    - rid: 6402840522224042053
+      type: {class: FontSettingsBinder, ns: MVVMDatabinding.Theming, asm: MVVM-Databinding}
+      data:
+        themeTemplate: {fileID: 11400000, guid: a8f1cd482cd3b014ea8d510aaa73f04e,
+          type: 2}
+        itemId: 105789788
+        name: Settings (FontSettingsBinder)
+        themeStyle: {fileID: 11400000, guid: 137dd63612b87594e801b764212f28a6, type: 2}
+        text: {fileID: 775382738}
+--- !u!114 &775382738
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 775382734}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: I use a different style!
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281808695
+  m_fontColor: {r: 0.21698111, g: 0.21698111, b: 0.21698111, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &775382739
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 775382734}
+  m_CullTransparentMesh: 1
 --- !u!1 &813694286
 GameObject:
   m_ObjectHideFlags: 0
@@ -3096,6 +3287,11 @@ PrefabInstance:
       propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
       value: 1801810542
       objectReference: {fileID: 0}
+    - target: {fileID: 4869112576578683191, guid: 2a0c9e724e3172342af028ccdac5d0a3,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 11.1
+      objectReference: {fileID: 0}
     - target: {fileID: 4869112576716521064, guid: 2a0c9e724e3172342af028ccdac5d0a3,
         type: 3}
       propertyPath: m_Name
@@ -3370,6 +3566,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 1224250799}
+    - targetCorrespondingSourceObject: {fileID: 4869112577306776474, guid: 2a0c9e724e3172342af028ccdac5d0a3,
+        type: 3}
+      insertIndex: 2
+      addedObject: {fileID: 775382735}
     - targetCorrespondingSourceObject: {fileID: 1979426453009896098, guid: 2a0c9e724e3172342af028ccdac5d0a3,
         type: 3}
       insertIndex: 0
@@ -3411,6 +3611,12 @@ MonoBehaviour:
     themeStyle: {fileID: 11400000, guid: 13acd0e3e3870ce47931ee42161838e9, type: 2}
   - template: {fileID: 11400000, guid: d6303cf62ea40b14487094f4dd920b0a, type: 2}
     themeStyle: {fileID: 11400000, guid: d2cc95a0e61ca9b429b76e4ccffe5b03, type: 2}
+--- !u!224 &4869112576897787564 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4869112577306776474, guid: 2a0c9e724e3172342af028ccdac5d0a3,
+    type: 3}
+  m_PrefabInstance: {fileID: 4869112576897787561}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5687866778677330697
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/com.kf.mvvm-data-binding/Runtime/Theming/Binders/BaseThemeBinder.cs
+++ b/com.kf.mvvm-data-binding/Runtime/Theming/Binders/BaseThemeBinder.cs
@@ -168,6 +168,7 @@ namespace MVVMDatabinding.Theming
         }
 
 #if UNITY_EDITOR
+        public ThemeStyleApplier ActiveApplier { get; set; }
         public ThemeStyleTemplate Template => themeTemplate;
         public int ItemId => itemId;
 

--- a/com.kf.mvvm-data-binding/Runtime/Theming/Binders/BaseThemeBinder.cs
+++ b/com.kf.mvvm-data-binding/Runtime/Theming/Binders/BaseThemeBinder.cs
@@ -172,6 +172,16 @@ namespace MVVMDatabinding.Theming
         public ThemeStyleTemplate Template => themeTemplate;
         public int ItemId => itemId;
 
+        public bool DoesApplierHaveValidStyle(ThemeStyleApplier applier)
+        {
+            if (applier == null)
+            {
+                return false;
+            }
+
+            return applier.TryFindStyleForItem(Template, itemId, out ThemeStyle style);
+        }
+
         public void Editor_ForceUpdateItemValue(object value)
         {
             OnDataUpdated((T)value);

--- a/com.kf.mvvm-data-binding/Runtime/Theming/Binders/IThemeBinder.cs
+++ b/com.kf.mvvm-data-binding/Runtime/Theming/Binders/IThemeBinder.cs
@@ -16,6 +16,7 @@ namespace MVVMDatabinding.Theming
 #if UNITY_EDITOR
         ThemeStyleTemplate Template { get; }
         int ItemId { get; }
+        ThemeStyleApplier ActiveApplier { get; set; }
         // NOTE: We're using object here only because this is strictly an Editor time call. 
         void Editor_ForceUpdateItemValue(object value);
         void Editor_ForceUpdateValueFromTheme(Theme theme);

--- a/com.kf.mvvm-data-binding/Runtime/Theming/Binders/IThemeBinder.cs
+++ b/com.kf.mvvm-data-binding/Runtime/Theming/Binders/IThemeBinder.cs
@@ -21,6 +21,7 @@ namespace MVVMDatabinding.Theming
         void Editor_ForceUpdateItemValue(object value);
         void Editor_ForceUpdateValueFromTheme(Theme theme);
         void Editor_SetStyle(ThemeStyle style);
+        bool DoesApplierHaveValidStyle(ThemeStyleApplier applier);
 #endif
     }
 }

--- a/com.kf.mvvm-data-binding/Runtime/Theming/ThemeStyleApplier.cs
+++ b/com.kf.mvvm-data-binding/Runtime/Theming/ThemeStyleApplier.cs
@@ -216,11 +216,16 @@ namespace MVVMDatabinding.Theming
 
                 foreach (IThemeBinder binder in cached.Binders)
                 {
+                    if (!binder.DoesApplierHaveValidStyle(this))
+                    {
+                        continue;
+                    }
+
                     if (binder.ActiveApplier == null)
                     {
                         binder.ActiveApplier = this;
                     }
-                    
+
                     if (binder.ActiveApplier == this)
                     {
                         binder.Editor_SetStyle(picker.Style);

--- a/com.kf.mvvm-data-binding/Runtime/Theming/ThemeStyleApplier.cs
+++ b/com.kf.mvvm-data-binding/Runtime/Theming/ThemeStyleApplier.cs
@@ -211,11 +211,51 @@ namespace MVVMDatabinding.Theming
         {
             foreach (ThemeBinder cached in cachedBinders)
             {
+                // determine relationship between the ThemeBinder and this ThemeStyleApplier in the hierarchy
+                int relationshipLevel = GetHierarchyDistance(transform, cached.transform);
+
                 foreach (IThemeBinder binder in cached.Binders)
                 {
-                    binder.Editor_SetStyle(picker.Style);
+                    if (binder.ActiveApplier == null)
+                    {
+                        binder.ActiveApplier = this;
+                    }
+                    
+                    if (binder.ActiveApplier == this)
+                    {
+                        binder.Editor_SetStyle(picker.Style);
+                    }
+                    else
+                    {
+                        // determine relationship between its current applier and the binder
+                        int existingLevel = GetHierarchyDistance(binder.ActiveApplier.transform, cached.transform);
+
+                        if (existingLevel > relationshipLevel)
+                        {
+                            binder.ActiveApplier = this;
+                            binder.Editor_SetStyle(picker.Style);
+                        }
+                    }
                 }
             }
+        }
+
+        private int GetHierarchyDistance(Transform higher, Transform lower)
+        {
+            if (higher == lower)
+            {
+                return 0;
+            }
+
+            int dist = 0;
+            Transform current = lower;
+            while (current != null && current != higher)
+            {
+                dist++;
+                current = current.parent;
+            }
+
+            return dist;
         }
 
         private void DiscoverThemeBinders(List<ThemeBinder> binders)


### PR DESCRIPTION
Before these changes, a parent ThemeStyleApplier would override one closer in the hierarchy and cause headaches for special case scenarios where you want part of the UI to use a different style (e.g.- font styling or color) than the parent applier is dictating.

This PR adds editor-time logic that compares the ThemeStyleApplier updating binders to a cached applier on each binder. In the case of a conflict, the applier with an applicable ThemeStyle configured that is closest to the ThemeBinder in the hierarchy takes priority for applying a style.